### PR TITLE
Run examples in Node 8.10.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       - image: circleci/node:10.15.1
   node8:
     docker:
-      - image: circleci/node:chakracore-8.10
+      - image: circleci/node:8.14.0
   node6:
     docker:
       - image: circleci/node:6.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       - image: circleci/node:10.15.1
   node8:
     docker:
-      - image: circleci/node:8.4
+      - image: circleci/node:8.10
   node6:
     docker:
       - image: circleci/node:6.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       - image: circleci/node:10.15.1
   node8:
     docker:
-      - image: circleci/node:8.0
+      - image: circleci/node:chakracore-8.10
   node6:
     docker:
       - image: circleci/node:6.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,5 +38,5 @@ workflows:
   test:
     jobs:
       - node10
-      # - node8
+      - node8
       # - node6  # Does not run before we use Babel to transform the test code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       - image: circleci/node:10.15.1
   node8:
     docker:
-      - image: circleci/node:8.14.0
+      - image: circleci/node:8.4
   node6:
     docker:
       - image: circleci/node:6.10

--- a/hello-world-javascript/hello.test.js
+++ b/hello-world-javascript/hello.test.js
@@ -1,17 +1,9 @@
 // hello.test.js
 const unmock = require("unmock-node").default;
 const axios = require("axios");
-const jsf = require("json-schema-faker");
 
-console.log("type of jsf", typeof jsf);
-console.log("type of jsf.default", typeof jsf.default);
-console.log("type of jsf.generate", typeof jsf.generate);
 beforeAll(() => {
   unmock.on();
-});
-
-test("jsf.generate type", async () => {
-  expect(typeof jsf.generate).toBe("function");
 });
 
 test("hello endpoint returns correct JSON", async () => {

--- a/hello-world-javascript/hello.test.js
+++ b/hello-world-javascript/hello.test.js
@@ -1,9 +1,15 @@
 // hello.test.js
 const unmock = require("unmock-node").default;
 const axios = require("axios");
+const jsf = require("json-schema-faker");
 
+console.log("type of jsf.generate", typeof jsf.generate);
 beforeAll(() => {
   unmock.on();
+});
+
+test("jsf.generate type", async () => {
+  expect(typeof jsf.generate).toBe("function");
 });
 
 test("hello endpoint returns correct JSON", async () => {

--- a/hello-world-javascript/hello.test.js
+++ b/hello-world-javascript/hello.test.js
@@ -3,6 +3,8 @@ const unmock = require("unmock-node").default;
 const axios = require("axios");
 const jsf = require("json-schema-faker");
 
+console.log("type of jsf", typeof jsf);
+console.log("type of jsf.default", typeof jsf.default);
 console.log("type of jsf.generate", typeof jsf.generate);
 beforeAll(() => {
   unmock.on();


### PR DESCRIPTION
- For some strange reason, running tests in `circleci/node:8.0` fails with `jsf.generate is not a function` but works fine in `circleci/node:8.10`, so use that for now.
- Tests also work fine locally when running `node:8.0` 